### PR TITLE
a bug on chinese client

### DIFF
--- a/Modules/Difficulty.lua
+++ b/Modules/Difficulty.lua
@@ -126,7 +126,7 @@ PGF.SHORTNAME_TO_DIFFICULTY = {
     [select(2, C_LFGList.GetActivityInfo(459))] = C.MYTHICPLUS, -- Mythic+
 }
 
-function PGF.ExtractNameSuffix(name) return name:lower():match("%(([^)]+)%)") end
+function PGF.ExtractNameSuffix(name) return name:lower():match("[(（]([^)）]+)[)）]") end
 
 -- maps localized name suffixes (the value in parens) from C_LFGList.GetActivityInfo() to difficulties
 PGF.NAMESUFFIX_TO_DIFFICULTY = {


### PR DESCRIPTION
On chinese client,C_LFGList.GetActivityInfo will return like this

>冰冠堡垒（10人普通） 10人普通 3 17 0 6 80 10 1 0 false true

On english client,like this

>Icecrown Citadel (10 Normal) 10 Normal 3 17 0 6 80 10 1 0 false true

（）is different to ()
I try fix it, Can you help me check this pr?

Thanks for your work.