### PR TITLE
Fix getting the RaiderIO profile because of the fact, that RaiderIO API has been changed

### DIFF
--- a/Plugins/RaiderIO.lua
+++ b/Plugins/RaiderIO.lua
@@ -73,8 +73,8 @@ function PGF.PutRaiderIOMetrics(env, leaderName)
     if leaderName and RaiderIO and RaiderIO.GetProfile then
         if RaiderIO.GetProfile then
             -- new API
-            local name, realm, faction = PGF.GetNameRealmFaction(leaderName)
-            local result = RaiderIO.GetProfile(name, realm, faction)
+            local name, realm = PGF.GetNameRealmFaction(leaderName)
+            local result = RaiderIO.GetProfile(name, realm)
             if not result and type(result) ~= "table" then
                 return
             end


### PR DESCRIPTION
Keywords "rio", "rioprev", "riomain" and other words from the section "RaiderIO" of the keywords list were broken.
RaiderIO API has changed, they've removed the parameter "faction" from the function GetProfile https://github.com/RaiderIO/raiderio-addon/blob/develop/core.lua#L3486
I've removed using "faction" from the part where the function GetProfile is called.