### PR TITLE
Fix state persistence and cross-faction profile wipes

### DIFF
--- a/UI/Common.lua
+++ b/UI/Common.lua
@@ -66,15 +66,19 @@ function PGF.UI_SetupMinMaxField(panel, field, keyword, size)
         field.Act:SetChecked(shouldCheck)
         panel.state[keyword].act = shouldCheck
     end
-    field.Min:SetScript("OnTextChanged", function(element)
-        autoCheckbox()
-        panel.state[keyword].min = element:GetText()
-        panel:TriggerFilterExpressionChange()
+    field.Min:SetScript("OnTextChanged", function(element, isUserInput)
+        if isUserInput then
+            autoCheckbox()
+            panel.state[keyword].min = element:GetText()
+            panel:TriggerFilterExpressionChange()
+        end
     end)
-    field.Max:SetScript("OnTextChanged", function(element)
-        autoCheckbox()
-        panel.state[keyword].max = element:GetText()
-        panel:TriggerFilterExpressionChange()
+    field.Max:SetScript("OnTextChanged", function(element, isUserInput)
+        if isUserInput then
+            autoCheckbox()
+            panel.state[keyword].max = element:GetText()
+            panel:TriggerFilterExpressionChange()
+        end
     end)
 
     -- tabbing
@@ -148,11 +152,20 @@ function PGF.UI_SetupAdvancedExpression(panel)
     local fontFile, _, fontFlags = panel.Advanced.Title:GetFont()
     panel.Advanced.Expression.EditBox:SetFont(fontFile, C.FONTSIZE_TEXTBOX, fontFlags)
     panel.Advanced.Expression.EditBox.Instructions:SetFont(fontFile, C.FONTSIZE_TEXTBOX, fontFlags)
-    panel.Advanced.Expression.EditBox:SetScript("OnTextChanged", InputScrollFrame_OnTextChanged)
+    panel.Advanced.Expression.EditBox:SetScript("OnTextChanged", function(self)
+        InputScrollFrame_OnTextChanged(self)
+        if panel.state then
+            panel.state.expression = self:GetText() or ""
+            -- Evaluate immediately so the underlying UI searches while typing
+            panel:TriggerFilterExpressionChange()
+        end
+    end)
     panel.Advanced.Expression.EditBox:SetScript("OnEscapePressed", InputScrollFrame_OnEscapePressed)
-    panel.Advanced.Expression.EditBox:SetScript("OnEditFocusLost", function (self)
-        panel.state.expression = self:GetText() or ""
-        panel:TriggerFilterExpressionChange()
+    panel.Advanced.Expression.EditBox:SetScript("OnEditFocusLost", function(self)
+        if panel.state then
+            panel.state.expression = self:GetText() or ""
+            panel:TriggerFilterExpressionChange()
+        end
     end)
     panel.Advanced.Info:SetScript("OnEnter", PGF.Dialog_InfoButton_OnEnter)
     panel.Advanced.Info:SetScript("OnLeave", PGF.Dialog_InfoButton_OnLeave)

--- a/UI/Dialog.lua
+++ b/UI/Dialog.lua
@@ -176,8 +176,10 @@ function PGFDialog:Toggle()
 end
 
 function PGFDialog:UpdateCategory(categoryID, filters, baseFilters)
-    PGF.Logger:Debug("PGFDialog:UpdateCategory(".. categoryID ..", "..filters..", "..baseFilters..")")
-    local allFilters = bit.bor(baseFilters, filters);
+    PGF.Logger:Debug("PGFDialog:UpdateCategory(".. tostring(categoryID) ..", "..tostring(filters)..", "..tostring(baseFilters)..")")
+    local allFilters = bit.bor(baseFilters or 0, filters or 0);
+    -- Mask out volatile bits like Cross-Faction (128) to prevent profile wiping (only retain 1, 2, 4, 8)
+    allFilters = bit.band(allFilters, 15);
     local id = "c"..categoryID.."f"..allFilters
     self.activeId = id
     self.activeState = self:GetState(id)


### PR DESCRIPTION
This PR resolves a series of interconnected bugs that were unintentionally wiping user profiles and discarding configurations under certain conditions:

**1. Prevented "Cross-Faction" from wiping Profile States**
`preferredFilters` natively updates whenever a user toggles "Cross-Faction Play" or selects languages in the Blizzard UI. Because PGF blindly incorporated this bitmask into its profile generator ID (`allFilters = bit.bor`), toggling Cross-Faction created an entirely new, blank state array (e.g. going from `c2f4` to `c2f5`). Users thought their filters were arbitrarily getting deleted when they clicked anything outside PGF.
*Fix: Clamped the `bit.band` explicitly to `15` to only respect core PvE/PvP/Recommended bits!*

**2. Fixed `autoCheckbox` force-deleting manual checkbox states**
When reopening the LFG Window, `Init()` naturally restores configurations using `SetText()`. However, `SetText` mistakenly triggered `OnTextChanged`, causing `autoCheckbox()` to evaluate in the background. If a user had checked a box but left the text field empty, `autoCheckbox` would aggressively reset their checkbox to `false` during the frame load.
*Fix: PGF now only fires `autoCheckbox` validations if `isUserInput` evaluates dynamically to true.*

**3. Fixed data loss on `Advanced Expression` string inputs**
When users typed an advanced expression, PGF only committed the string to `SavedVariables` when the text box physically received an `OnEditFocusLost` event. If a user typed a string and instantly closed the LFG window (via hitting 'X'), the application tore down before focus was formally resolved, silently discarding their string! 
*Fix: Linked state string persistence directly into the `OnTextChanged` event, ensuring one-to-one keystroke syncing.*
