### PR TITLE
Feature: Add native Group Age UI timer to LFG entries

### DIFF
--- a/Init.lua
+++ b/Init.lua
@@ -199,6 +199,7 @@ C.SETTINGS_DEFAULT = {
     coloredGroupTexts = true,
     compactListEntries = false,
     ratingInfo = true,
+    groupAgeTimer = true,
     specIcon = false,
     classCircle = false,
     classBar = false,

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -162,3 +162,6 @@ L["settings.warning.taint"] = "This option can cause Lua errors in restricted si
 
 L["dialog.restriction.text"] = "Addon restrictions are active. Filtering may cause Lua errors."
 L["dialog.restriction.ok"] = "Filter anyway"
+
+L["settings.groupAgeTimer.title"] = "Group Age Timer"
+L["settings.groupAgeTimer.tooltip"] = "Shows a timer in the group's playstyle area indicating how long the group has been listed."

--- a/Main.lua
+++ b/Main.lua
@@ -422,10 +422,35 @@ end
 function PGF.OnLFGListSearchEntryUpdate(self)
     local searchResultInfo = PGF.GetSearchResultInfo(self.resultID)
     if not searchResultInfo then return end
-    --self.Name:SetText("r:"..self.resultID .. " a:"..select(2, C_LFGList.GetApplicationInfo(self.resultID)).." "..self.Name:GetText())
+
     PGF.ColorGroupTexts(self, searchResultInfo)
     PGF.AddRoleIndicators(self, searchResultInfo)
     PGF.AddRatingInfo(self, searchResultInfo)
+
+    if PremadeGroupsFilterSettings.groupAgeTimer and searchResultInfo.age and searchResultInfo.age > 0 then
+        local ageMins = math.floor(searchResultInfo.age / 60)
+        local ageStr = ""
+        local colorCode = "|cff00ccff" -- Crisp Cyan (contrasts perfectly with Yellow and Green)
+
+        if ageMins >= 60 then
+            local hours = math.floor(ageMins / 60)
+            local mins = ageMins % 60
+            ageStr = hours .. "h " .. mins .. "m"
+        elseif ageMins > 0 then
+            ageStr = ageMins .. "m"
+        else
+            ageStr = "<1m"
+        end
+        local currentText = self.Playstyle:GetText() or ""
+        -- Strip any previously injected age tags (handles matching multiple colors)
+        currentText = string.gsub(currentText, "^|cff%x%x%x%x%x%x%[.-%]|r ", "")
+        -- Prepend the age onto the Playstyle text (e.g., "Learning", "Beat Timer")
+        if currentText ~= "" then
+            self.Playstyle:SetText(colorCode .. "[" .. ageStr .. "]|r " .. currentText)
+        else
+            self.Playstyle:SetText(colorCode .. "[" .. ageStr .. "]|r")
+        end
+    end
 end
 
 function PGF.OnLFGListSearchPanelUpdateResultList(self)

--- a/Settings/Settings.lua
+++ b/Settings/Settings.lua
@@ -70,6 +70,13 @@ local PGFSettingsTable = {
         visible = true,
     },
     {
+        key = "groupAgeTimer",
+        type = "checkbox",
+        title = L["settings.groupAgeTimer.title"],
+        tooltip = L["settings.groupAgeTimer.tooltip"],
+        visible = true,
+    },
+    {
         key = "rioRatingColors",
         type = "checkbox",
         title = L["settings.rioRatingColors.title"],


### PR DESCRIPTION
This PR introduces a small, unintrusive UI enhancement that displays how long a group has been listed in the Group Finder directly on the search results pane.

It's historically been quite hard to tell if a group is completely fresh or has been rotting in the queue for 45 minutes. This change fixes that by dynamically formatting `searchResultInfo.age` and embedding a timer directly into the existing Playstyle text block.

**Key features:**
* **Clean Formatting**: Formats the age dynamically based on staleness (e.g., `[<1m]`, `[14m]`, `[1h 22m]`).
* **High Contrast**: Uses a bright Cyan (`#00ccff`) hex code to perfectly contrast against the native neon green playstyles and yellow group titles, making it easily readable at a glance.
* **Layout Immune**: Protects against aggressive right-side string truncation by natively prepending the timer to the left edge of the Playstyle font string matrix.
* **Fully Toggleable**: Hooked natively into PGF's Settings UI panel. It defaults to 'On', but players can toggle the "Group Age Timer" checkbox off at any time under the standard PremadeGroupsFilter addon options interface!
