### PR TITLE
Feature: Clean up UI by truncating redundant (Mythic Keystone) text f…

### DIFF
--- a/Main.lua
+++ b/Main.lua
@@ -423,6 +423,14 @@ function PGF.OnLFGListSearchEntryUpdate(self)
     local searchResultInfo = PGF.GetSearchResultInfo(self.resultID)
     if not searchResultInfo then return end
     --self.Name:SetText("r:"..self.resultID .. " a:"..select(2, C_LFGList.GetApplicationInfo(self.resultID)).." "..self.Name:GetText())
+    
+    local activityInfo = PGF.GetActivityInfoTable(searchResultInfo.activityID)
+    if activityInfo and activityInfo.isMythicPlusActivity then
+        local currentName = self.ActivityName:GetText() or ""
+        -- Strip " (Mythic Keystone)" natively regardless of localization language
+        self.ActivityName:SetText(string.gsub(currentName, "%s*%(.*%)", ""))
+    end
+
     PGF.ColorGroupTexts(self, searchResultInfo)
     PGF.AddRoleIndicators(self, searchResultInfo)
     PGF.AddRatingInfo(self, searchResultInfo)


### PR DESCRIPTION
This PR is a minor UI quality-of-life clean up.

In World of Warcraft, Blizzard natively appends ` (Mythic Keystone)` to the localized `ActivityName` of any group listed under Mythic Plus difficulty (e.g., `"The Stonevault (Mythic Keystone)"`). Because Premade Groups Filter is explicitly designed to curate these listings visually and mathematically, this extra default string consumes a massive chunk of screen real estate entirely redundantly, accelerating right-side text truncation. 

*Fix: Added a locale-agnostic regex block (`"%s*%(.*%)"`) prior to the text colorization loop that strips this text from any group definitively classified under `activityInfo.isMythicPlusActivity`. This cleans up the UI and forces native truncation algorithms further back!*
