### PR TITLE
[codex] Add hasmyclassrole keyword

### DIFF
--- a/Modules/MemberInfo.lua
+++ b/Modules/MemberInfo.lua
@@ -28,6 +28,7 @@ function PGF.PutSearchResultMemberInfos(resultID, searchResultInfo, env)
     env.ranged = 0
     env.melees = 0
     env.hasmyclass = false
+    env.hasmyclassrole = false
     env.hasmyspec = false
     env.hasmyarmor = false
     env.hasleaver = false
@@ -64,6 +65,9 @@ function PGF.PutSearchResultMemberInfos(resultID, searchResultInfo, env)
                 end
                 if mySpecInfo.classKeyword == specInfo.classKeyword then
                     env.hasmyclass = true
+                    if mySpecInfo.role == specInfo.role then
+                        env.hasmyclassrole = true
+                    end
                     if mySpecInfo.specKeyword == specInfo.specKeyword then
                         env.hasmyspec = true
                     end


### PR DESCRIPTION
## Summary
- add `hasmyclassrole` to the filter environment
- set it when a search-result member matches the player's current class and role

## Why
This extends the existing `hasmyclass` / `hasmyspec` keyword family and lets players filter with expressions like `not hasmyclassrole` when they want to avoid groups that already contain their current class in their current role.

## Validation
- `luac -p Modules/MemberInfo.lua`
- local harness covering DPS Death Knight vs DPS Death Knight and DPS Death Knight vs Blood Death Knight
