### PR TITLE
Add Sporefall Mythic activity

### DIFF
--- a/Modules/Activity.lua
+++ b/Modules/Activity.lua
@@ -683,6 +683,7 @@ C.ACTIVITY = {
     [1795] = { difficulty = 4, category =   2, mapID = 1493, cmID = 207 }, -- Vault of the Wardens (Mythic Keystone)
     [1945] = { difficulty = 4, category =   2, mapID = 1677, cmID = 233 }, -- Cathedral of Eternal Night (Mythic Keystone)
     [1946] = { difficulty = 1, category =   3, mapID = 1592, cmID =   0 }, -- Sporefall (Normal)
+    [1947] = { difficulty = 3, category =   3, mapID = 1592, cmID =   0 }, -- Sporefall (Mythic)
     [1948] = { difficulty = 2, category =   3, mapID = 1592, cmID =   0 }, -- Sporefall (Heroic)
 }
 


### PR DESCRIPTION
## What changed

Added the missing Mythic activity entry for the Sporefall raid.

## Why

Sporefall Normal (1946) and Heroic (1948) are already present, but Mythic
activity 1947 is missing. As a result, Mythic Sporefall groups are assigned
difficulty 0 and are excluded when the Mythic raid filter is enabled.

## Change

```lua
[1947] = { difficulty = 3, category = 3, mapID = 1592, cmID = 0 }, -- Sporefall (Mythic)