### PR TITLE
fix: create the popup menu frame at load time

### DIFF
--- a/UI/PopupMenu.lua
+++ b/UI/PopupMenu.lua
@@ -24,8 +24,22 @@ local C = PGF.C
 
 local popupMenus = {}
 local popupMenuActive
-local popupFrame
 local popupEntrySelected = {}
+
+-- The menu is shared by all dropdowns and created up front, so that it is available
+-- to addons styling the frames exported at the bottom of this file.
+local popupFrame = CreateFrame("Frame", nil, nil, "PremadeGroupsFilterPopupMenuFrameTemplate")
+popupFrame:Hide()
+popupFrame:EnableKeyboard(true)
+popupFrame:SetScript("OnKeyDown", function (self, key)
+    if key == GetBindingKey("TOGGLEGAMEMENU") then
+        PGF.PopupMenu_Hide()
+        self:SetPropagateKeyboardInput(false)
+    else
+        self:SetPropagateKeyboardInput(true)
+    end
+end)
+popupFrame.Buttons = {}
 
 -- entry = { title = "", value = 0, func = function (entry) end }
 
@@ -47,25 +61,10 @@ end
 function PGF.PopupMenu_Initialize(name)
     local menu = popupMenus[name]
 
-    -- create frame if it does not yet exist
-    if not popupFrame then
-        popupFrame = CreateFrame("Frame", nil, nil, "PremadeGroupsFilterPopupMenuFrameTemplate")
-        popupFrame:EnableKeyboard(true)
-        popupFrame:SetScript("OnKeyDown", function (self, key)
-            if key == GetBindingKey("TOGGLEGAMEMENU") then
-                PGF.PopupMenu_Hide()
-                self:SetPropagateKeyboardInput(false)
-            else
-                self:SetPropagateKeyboardInput(true)
-            end
-        end)
-    end
-
     -- set up buttons
     local buttonWidth = menu.minWidth
     local buttonHeight = 20
     local buttonOffsetY = -4
-    if not popupFrame.Buttons then popupFrame.Buttons = {} end
     for i, entry in ipairs(menu.entries) do
         -- create new buttons if necessary
         local button = popupFrame.Buttons[i]
@@ -121,7 +120,7 @@ end
 
 function PGF.PopupMenu_Hide()
     popupMenuActive = nil
-    if popupFrame then popupFrame:Hide() end
+    popupFrame:Hide()
 end
 
 function PGF.PopupMenu_Toggle(name)


### PR DESCRIPTION
`PremadeGroupsFilter.PopupMenuFrame` is assigned at the bottom of `UI/PopupMenu.lua` from the file-scope local `popupFrame`, which is still `nil` at that point. The lazy creation inside `PopupMenu_Initialize` only rebinds the local, so the exported field stays `nil` forever — even after a menu has been opened.

Creating the shared menu frame up front makes the export valid from load onwards, which is what addons styling the exported frames need. Side effects of moving it out of `PopupMenu_Initialize`:

- The frame is hidden explicitly after creation, since it is no longer created on the way into `PopupMenu_Show`.
- `popupFrame.Buttons` is initialized alongside the frame, so the `if not popupFrame.Buttons` guard in `PopupMenu_Initialize` is gone.
- `PopupMenu_Hide` no longer needs its `if popupFrame` check.

Behavior is otherwise unchanged: the menu is still shared by all dropdowns and still (re)initialized per dropdown on show.